### PR TITLE
Bump to google-cloud-sdk 234.0.0 release

### DIFF
--- a/google-cloud-sdk/.SRCINFO
+++ b/google-cloud-sdk/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = google-cloud-sdk
 	pkgdesc = A set of command-line tools for the Google Cloud Platform. Includes gcloud (with beta and alpha commands), gsutil, and bq.
-	pkgver = 233.0.0
+	pkgver = 234.0.0
 	pkgrel = 1
 	url = https://cloud.google.com/sdk/
 	arch = x86_64
@@ -9,9 +9,9 @@ pkgbase = google-cloud-sdk
 	optdepends = python2-crcmod: [gsutil] verify the integrity of GCS object contents
 	options = !strip
 	options = staticlibs
-	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-sdk_233.0.0.orig.tar.gz
+	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-sdk_234.0.0.orig.tar.gz
 	source = google-cloud-sdk.sh
-	sha256sums = f5f368eff857a2f012a807571603a7ddac473a33dba05413718c0775c2423482
+	sha256sums = d0d08a2d0e7cca2b2947b8848a0784a9a8e1b5193936a41eaa85eb66ad21b552
 	sha256sums = 36ac88de630e49ea4b067b1f5f229142e4cf97561b98b3bd3d8115a356946692
 
 pkgname = google-cloud-sdk

--- a/google-cloud-sdk/PKGBUILD
+++ b/google-cloud-sdk/PKGBUILD
@@ -6,7 +6,7 @@
 # Contributor: Justin Dray <justin@dray.be>
 
 pkgname="google-cloud-sdk"
-pkgver=233.0.0
+pkgver=234.0.0
 pkgrel=1
 pkgdesc="A set of command-line tools for the Google Cloud Platform. Includes gcloud (with beta and alpha commands), gsutil, and bq."
 url="https://cloud.google.com/sdk/"
@@ -21,7 +21,7 @@ source=(
   "google-cloud-sdk.sh"
 )
 sha256sums=(
-  'f5f368eff857a2f012a807571603a7ddac473a33dba05413718c0775c2423482'
+  'd0d08a2d0e7cca2b2947b8848a0784a9a8e1b5193936a41eaa85eb66ad21b552'
   '36ac88de630e49ea4b067b1f5f229142e4cf97561b98b3bd3d8115a356946692'
 )
 


### PR DESCRIPTION
Went to use this in the AUR last night and noticed the package is out of date. This diff will update the PKGBUILD to the latest official release.