### PR TITLE
gcloud: Add makedepends on ping

### DIFF
--- a/google-cloud-sdk/PKGBUILD
+++ b/google-cloud-sdk/PKGBUILD
@@ -13,6 +13,7 @@ url="https://cloud.google.com/sdk/"
 license=("Apache")
 arch=('x86_64')
 depends=('python2')
+makedepends=('ping')
 optdepends=('python2-crcmod: [gsutil] verify the integrity of GCS object contents')
 options=('!strip' 'staticlibs')
 


### PR DESCRIPTION
Building in a chroot will consistently log `Unable to reach dl.google.com, cannot determine latest upstream release`. This happens because ping is used to determine connectivity but ping is not part of base or base-devel so not available in chroots create with `mkarchchroot` unless the chroot is modified.

This adds ping to `makedepends` to ensure it's available while building the package. However, it should not be necessary to do so upfront and it's probably better to check `curl`'s exit code instead of the extra layer of using ping. If Google were to stop responding to ping this would also break, regardless of whether ping was installed or not, even though the HTTP request might still work.