### PR TITLE
Add an AUR package for the google-cloud-sdk datastore-emulator component.

### DIFF
--- a/google-cloud-sdk-datastore-emulator/.SRCINFO
+++ b/google-cloud-sdk-datastore-emulator/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = google-cloud-sdk-datastore-emulator
+	pkgdesc = A google-cloud-sdk component that provides local emulation of a Datastore environment.
+	pkgver = 290.0.0
+	pkgrel = 1
+	url = https://cloud.google.com/sdk/
+	arch = x86_64
+	license = Apache
+	depends = google-cloud-sdk=290.0.0
+	depends = java-runtime
+	options = !strip
+	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-sdk-datastore-emulator_290.0.0.orig.tar.gz
+	sha256sums = 8e6b9d0abab658c2bcc5197adac055498be35e032090f98abdd8170b691be98c
+
+pkgname = google-cloud-sdk-datastore-emulator
+

--- a/google-cloud-sdk-datastore-emulator/PKGBUILD
+++ b/google-cloud-sdk-datastore-emulator/PKGBUILD
@@ -1,0 +1,28 @@
+# Maintainer: Benjamin Denhartog <ben@sudoforge.com>
+# Contributor: Greg Darke <darke+arch@google.com>
+
+pkgname=google-cloud-sdk-datastore-emulator
+pkgver=290.0.0
+pkgrel=1
+pkgdesc="A google-cloud-sdk component that provides local emulation of a Datastore environment."
+url="https://cloud.google.com/sdk/"
+license=("Apache")
+arch=('x86_64')
+options=('!strip')
+depends=(
+  "google-cloud-sdk=${pkgver}"
+  "java-runtime"
+)
+source=(
+  "https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/${pkgname}_${pkgver}.orig.tar.gz"
+)
+sha256sums=('8e6b9d0abab658c2bcc5197adac055498be35e032090f98abdd8170b691be98c')
+
+package() {
+  mkdir "${pkgdir}/opt"
+  cp -r "${srcdir}/google-cloud-sdk" "${pkgdir}/opt"
+
+  # Remove unneeded files
+  rm "${pkgdir}/opt/google-cloud-sdk/platform/cloud-datastore-emulator/cloud_datastore_emulator.cmd"
+  rmdir "${pkgdir}/opt/google-cloud-sdk/.install/.download"
+}


### PR DESCRIPTION
Adding an explicit package for the datastore-emulator component of the Google cloud sdk to make it easier to install, and cleaner to remove when working on new machines.

I wanted to use this package to perform local development, but could not figure out how to install this component locally. Turns out it is just easier to package it.

This package will need to be updated at the same time as the google-cloud-sdk package (I bound the version of this package to the other one to ensure that nothing weird happens due to version skew).

I am not sure if you have automation that fetches new versions, but you want to 