### PR TITLE
Add `app-engine-python` and `app-engine-python-extras` packages

### DIFF
--- a/google-cloud-sdk-app-engine-python-extras/.SRCINFO
+++ b/google-cloud-sdk-app-engine-python-extras/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = google-cloud-sdk-app-engine-python-extras
+	pkgdesc = A google-cloud-sdk component that provides extra libraries for the Python runtime for AppEngine.
+	pkgver = 290.0.1
+	pkgrel = 1
+	url = https://cloud.google.com/sdk/
+	arch = x86_64
+	license = Apache
+	depends = google-cloud-sdk=290.0.1
+	depends = google-cloud-sdk-app-engine-python=290.0.1
+	options = !strip
+	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-sdk-app-engine-python-extras_290.0.1.orig.tar.gz
+	sha256sums = b6a16aa3186539ee813bec73dc15d912e553ec5eb8365ddb403a4e67dbd914b8
+
+pkgname = google-cloud-sdk-app-engine-python-extras
+

--- a/google-cloud-sdk-app-engine-python-extras/PKGBUILD
+++ b/google-cloud-sdk-app-engine-python-extras/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Benjamin Denhartog <ben@sudoforge.com>
+# Contributor: Tim Brown <stimut@gmail.com>
+
+pkgname=google-cloud-sdk-app-engine-python-extras
+pkgver=290.0.1
+pkgrel=1
+pkgdesc="A google-cloud-sdk component that provides extra libraries for the Python runtime for AppEngine."
+url="https://cloud.google.com/sdk/"
+license=("Apache")
+arch=('x86_64')
+options=('!strip')
+depends=(
+  "google-cloud-sdk=${pkgver}"
+  "google-cloud-sdk-app-engine-python=${pkgver}"
+)
+source=(
+  "https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/${pkgname}_${pkgver}.orig.tar.gz"
+)
+sha256sums=('b6a16aa3186539ee813bec73dc15d912e553ec5eb8365ddb403a4e67dbd914b8')
+
+package() {
+  mkdir "${pkgdir}/opt"
+
+  # Install the component manifest file
+  install -D -m 0644 \
+    "${srcdir}/google-cloud-sdk/.install/app-engine-python.manifest" \
+    "${pkgdir}/opt/google-cloud-sdk/.install/app-engine-python.manifest"
+
+  # Install the component metadata snapshot file
+  install -D -m 0644 \
+    "${srcdir}/google-cloud-sdk/.install/app-engine-python.snapshot.json" \
+    "${pkgdir}/opt/google-cloud-sdk/.install/app-engine-python.snapshot.json"
+
+  # Install the component files
+  cp -R \
+    "${srcdir}/google-cloud-sdk/platform/google_appengine" \
+    "${pkgdir}/opt/google-cloud-sdk/platform/google_appengine"
+}

--- a/google-cloud-sdk-app-engine-python/.SRCINFO
+++ b/google-cloud-sdk-app-engine-python/.SRCINFO
@@ -1,0 +1,15 @@
+pkgbase = google-cloud-sdk-app-engine-python
+	pkgdesc = A google-cloud-sdk component that provides the Python runtime for AppEngine.
+	pkgver = 290.0.1
+	pkgrel = 1
+	url = https://cloud.google.com/sdk/
+	arch = x86_64
+	license = Apache
+	depends = google-cloud-sdk=290.0.1
+	depends = python2
+	options = !strip
+	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-sdk-app-engine-python_290.0.1.orig.tar.gz
+	sha256sums = 0937c26ab56e7d47d0781c274e92fd985b6f02d7c08be28c4562557d258d7ff9
+
+pkgname = google-cloud-sdk-app-engine-python
+

--- a/google-cloud-sdk-app-engine-python/PKGBUILD
+++ b/google-cloud-sdk-app-engine-python/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Benjamin Denhartog <ben@sudoforge.com>
+# Contributor: Tim Brown <stimut@gmail.com>
+
+pkgname=google-cloud-sdk-app-engine-python
+pkgver=290.0.1
+pkgrel=1
+pkgdesc="A google-cloud-sdk component that provides the Python runtime for AppEngine."
+url="https://cloud.google.com/sdk/"
+license=("Apache")
+arch=('x86_64')
+options=('!strip')
+depends=(
+  "google-cloud-sdk=${pkgver}"
+  "python2"
+)
+source=(
+  "https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/${pkgname}_${pkgver}.orig.tar.gz"
+)
+sha256sums=('0937c26ab56e7d47d0781c274e92fd985b6f02d7c08be28c4562557d258d7ff9')
+
+package() {
+  mkdir "${pkgdir}/opt"
+
+  # Install the component manifest file
+  install -D -m 0644 \
+    "${srcdir}/google-cloud-sdk/.install/app-engine-python.manifest" \
+    "${pkgdir}/opt/google-cloud-sdk/.install/app-engine-python.manifest"
+
+  # Install the component metadata snapshot file
+  install -D -m 0644 \
+    "${srcdir}/google-cloud-sdk/.install/app-engine-python.snapshot.json" \
+    "${pkgdir}/opt/google-cloud-sdk/.install/app-engine-python.snapshot.json"
+
+  # Install the component files
+  cp -R \
+    "${srcdir}/google-cloud-sdk/platform/google_appengine" \
+    "${pkgdir}/opt/google-cloud-sdk/platform/google_appengine"
+}


### PR DESCRIPTION
Add explicit packages for the `app-engine-python` and `app-engine-python-extras` Google Cloud SDK components.

These packages are based off the `google-cloud-sdk-datastore-emulator` package, hence crediting Greg in the PKGBUILDs.

If you don't want to be the maintainer of these packages, I'm happy to do that separately.