### PR TITLE
Create the needed paths to copy the files into

### DIFF
--- a/google-cloud-sdk-app-engine-python-extras/PKGBUILD
+++ b/google-cloud-sdk-app-engine-python-extras/PKGBUILD
@@ -19,7 +19,7 @@ source=(
 sha256sums=('b6a16aa3186539ee813bec73dc15d912e553ec5eb8365ddb403a4e67dbd914b8')
 
 package() {
-  mkdir "${pkgdir}/opt"
+  mkdir -p "${pkgdir}/opt/google-cloud-sdk/platform/google_appengine"
 
   # Install the component manifest file
   install -D -m 0644 \

--- a/google-cloud-sdk-app-engine-python/PKGBUILD
+++ b/google-cloud-sdk-app-engine-python/PKGBUILD
@@ -19,7 +19,7 @@ source=(
 sha256sums=('0937c26ab56e7d47d0781c274e92fd985b6f02d7c08be28c4562557d258d7ff9')
 
 package() {
-  mkdir "${pkgdir}/opt"
+  mkdir -p "${pkgdir}/opt/google-cloud-sdk/platform/google_appengine"
 
   # Install the component manifest file
   install -D -m 0644 \


### PR DESCRIPTION
The currently available PKGBUILDs do not build for me with `yay` as the
directory that the component files get copied into does not exist.

This PR simply changes the creation of `${pkgdir}/opt` to create the
full depth of directories needed.

By the way, thanks for merging the original PR.