### PR TITLE
Fix the manifest and snapshot paths in py-extras

### DIFF
--- a/google-cloud-sdk-app-engine-python-extras/.SRCINFO
+++ b/google-cloud-sdk-app-engine-python-extras/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = google-cloud-sdk-app-engine-python-extras
 	pkgdesc = A google-cloud-sdk component that provides extra libraries for the Python runtime for AppEngine.
 	pkgver = 290.0.1
-	pkgrel = 2
+	pkgrel = 3
 	url = https://cloud.google.com/sdk/
 	arch = x86_64
 	license = Apache

--- a/google-cloud-sdk-app-engine-python-extras/PKGBUILD
+++ b/google-cloud-sdk-app-engine-python-extras/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=google-cloud-sdk-app-engine-python-extras
 pkgver=290.0.1
-pkgrel=2
+pkgrel=3
 pkgdesc="A google-cloud-sdk component that provides extra libraries for the Python runtime for AppEngine."
 url="https://cloud.google.com/sdk/"
 license=("Apache")

--- a/google-cloud-sdk-app-engine-python-extras/PKGBUILD
+++ b/google-cloud-sdk-app-engine-python-extras/PKGBUILD
@@ -23,13 +23,13 @@ package() {
 
   # Install the component manifest file
   install -D -m 0644 \
-    "${srcdir}/google-cloud-sdk/.install/app-engine-python.manifest" \
-    "${pkgdir}/opt/google-cloud-sdk/.install/app-engine-python.manifest"
+    "${srcdir}/google-cloud-sdk/.install/app-engine-python-extras.manifest" \
+    "${pkgdir}/opt/google-cloud-sdk/.install/app-engine-python-extras.manifest"
 
   # Install the component metadata snapshot file
   install -D -m 0644 \
-    "${srcdir}/google-cloud-sdk/.install/app-engine-python.snapshot.json" \
-    "${pkgdir}/opt/google-cloud-sdk/.install/app-engine-python.snapshot.json"
+    "${srcdir}/google-cloud-sdk/.install/app-engine-python-extras.snapshot.json" \
+    "${pkgdir}/opt/google-cloud-sdk/.install/app-engine-python-extras.snapshot.json"
 
   # Install the component files
   cp -R \


### PR DESCRIPTION
The manifest and snapshot paths in the
google-cloud-sdk-app-engine-python-extras package are missing the
`extras`.

This PR simply fixes those paths by adding `-extras`.