### PR TITLE
google-cloud-sdk: install zsh completion

### DIFF
--- a/google-cloud-sdk/.SRCINFO
+++ b/google-cloud-sdk/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = google-cloud-sdk
 	pkgdesc = A set of command-line tools for the Google Cloud Platform. Includes gcloud (with beta and alpha commands), gsutil, and bq.
 	pkgver = 290.0.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://cloud.google.com/sdk/
 	arch = x86_64
 	license = Apache
@@ -14,10 +14,12 @@ pkgbase = google-cloud-sdk
 	source = google-cloud-sdk.sh
 	source = 0001-set-python2-for-dev-appserver-py.patch
 	source = 0002-set-python2-for-endpointscfg-py.patch
+	source = 0003-add-compdef-to-zsh-completion.patch
 	sha256sums = 6429195023b30530ffc68d86de7f2dfb96c321df51f3a5a23d619c72441c2ade
 	sha256sums = a54f88947a2593fae4aa8f65e42de4ad735583ae743735305c0f36710a794295
 	sha256sums = 62ec7f56e09168d375823e9e99fcdcfbf40b0fffdd75f35cf91122c5902c82e9
 	sha256sums = ff6065ce2e54ac654605bd5fe554313b1d0def2c31ce56ff39429098dd1e39fe
+	sha256sums = 4694f5191ceea7cf8076861ce5790ba9e809023da278b0f6ed862b9611e5aa93
 
 pkgname = google-cloud-sdk
 

--- a/google-cloud-sdk/0003-add-compdef-to-zsh-completion.patch
+++ b/google-cloud-sdk/0003-add-compdef-to-zsh-completion.patch
@@ -1,0 +1,9 @@
+diff -urN --color a/completion.zsh.inc b/completion.zsh.inc
+--- a/completion.zsh.inc	2020-05-04 13:47:11.211895195 +0200
++++ b/completion.zsh.inc	2020-05-04 13:47:32.197626189 +0200
+@@ -1,3 +1,5 @@
++#compdef gcloud
++
+ autoload -U +X bashcompinit && bashcompinit
+ zmodload -i zsh/parameter
+ if ! (( $+functions[compdef] )) ; then

--- a/google-cloud-sdk/PKGBUILD
+++ b/google-cloud-sdk/PKGBUILD
@@ -7,7 +7,7 @@
 
 pkgname="google-cloud-sdk"
 pkgver=290.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of command-line tools for the Google Cloud Platform. Includes gcloud (with beta and alpha commands), gsutil, and bq."
 url="https://cloud.google.com/sdk/"
 license=("Apache")
@@ -23,11 +23,13 @@ source=(
   "google-cloud-sdk.sh"
   "0001-set-python2-for-dev-appserver-py.patch"
   "0002-set-python2-for-endpointscfg-py.patch"
+  "0003-add-compdef-to-zsh-completion.patch"
 )
 sha256sums=('6429195023b30530ffc68d86de7f2dfb96c321df51f3a5a23d619c72441c2ade'
             'a54f88947a2593fae4aa8f65e42de4ad735583ae743735305c0f36710a794295'
             '62ec7f56e09168d375823e9e99fcdcfbf40b0fffdd75f35cf91122c5902c82e9'
-            'ff6065ce2e54ac654605bd5fe554313b1d0def2c31ce56ff39429098dd1e39fe')
+            'ff6065ce2e54ac654605bd5fe554313b1d0def2c31ce56ff39429098dd1e39fe'
+            '4694f5191ceea7cf8076861ce5790ba9e809023da278b0f6ed862b9611e5aa93')
 
 prepare() {
   cd "${srcdir}/${pkgname}"
@@ -68,6 +70,9 @@ package() {
 
   install -D -m 0644 "${pkgdir}/opt/${pkgname}/completion.bash.inc" \
     "${pkgdir}/etc/bash_completion.d/google-cloud-sdk"
+
+  install -D -m 0644 "${pkgdir}/opt/${pkgname}/completion.zsh.inc" \
+    "${pkgdir}/usr/share/zsh/site-functions/_gcloud"
 
   mkdir -p "${pkgdir}/usr/share"
   mv -f "${pkgdir}/opt/${pkgname}/help/man" "${pkgdir}/usr/share/"


### PR DESCRIPTION
Hi @sudoforge,

Here's a small change to install gcloud autocompletion for zsh users.

The implementation comes from upstream, however the file needs a `#compdef` header to be included by zsh when placed in `fpath`, so I added a small patch for that.

Hope this is useful - please let me know if I missed something wrt contribution guidelines or similar.