### PR TITLE
Remove explicit version dependency for cloud sdk components.

### DIFF
--- a/google-cloud-sdk-app-engine-python-extras/.SRCINFO
+++ b/google-cloud-sdk-app-engine-python-extras/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = google-cloud-sdk-app-engine-python-extras
 	pkgdesc = A google-cloud-sdk component that provides extra libraries for the Python runtime for AppEngine.
 	pkgver = 292.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://cloud.google.com/sdk/
 	arch = x86_64
 	license = Apache
-	depends = google-cloud-sdk=292.0.0
-	depends = google-cloud-sdk-app-engine-python=292.0.0
+	depends = google-cloud-sdk
+	depends = google-cloud-sdk-app-engine-python
 	options = !strip
 	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-sdk-app-engine-python-extras_292.0.0.orig.tar.gz
 	sha256sums = 282f3aeccdb1a7d96b6f0918bcb13e9151a3330dac20a7e4b0f0dc1782959bb4

--- a/google-cloud-sdk-app-engine-python-extras/PKGBUILD
+++ b/google-cloud-sdk-app-engine-python-extras/PKGBUILD
@@ -3,15 +3,15 @@
 
 pkgname=google-cloud-sdk-app-engine-python-extras
 pkgver=292.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A google-cloud-sdk component that provides extra libraries for the Python runtime for AppEngine."
 url="https://cloud.google.com/sdk/"
 license=("Apache")
 arch=('x86_64')
 options=('!strip')
 depends=(
-  "google-cloud-sdk=${pkgver}"
-  "google-cloud-sdk-app-engine-python=${pkgver}"
+  "google-cloud-sdk"
+  "google-cloud-sdk-app-engine-python"
 )
 source=(
   "https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/${pkgname}_${pkgver}.orig.tar.gz"

--- a/google-cloud-sdk-app-engine-python/.SRCINFO
+++ b/google-cloud-sdk-app-engine-python/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = google-cloud-sdk-app-engine-python
 	pkgdesc = A google-cloud-sdk component that provides the Python runtime for AppEngine.
 	pkgver = 292.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://cloud.google.com/sdk/
 	arch = x86_64
 	license = Apache
-	depends = google-cloud-sdk=292.0.0
+	depends = google-cloud-sdk
 	depends = python2
 	options = !strip
 	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-sdk-app-engine-python_292.0.0.orig.tar.gz

--- a/google-cloud-sdk-app-engine-python/PKGBUILD
+++ b/google-cloud-sdk-app-engine-python/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=google-cloud-sdk-app-engine-python
 pkgver=292.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A google-cloud-sdk component that provides the Python runtime for AppEngine."
 url="https://cloud.google.com/sdk/"
 license=("Apache")
 arch=('x86_64')
 options=('!strip')
 depends=(
-  "google-cloud-sdk=${pkgver}"
+  "google-cloud-sdk"
   "python2"
 )
 source=(

--- a/google-cloud-sdk-datastore-emulator/.SRCINFO
+++ b/google-cloud-sdk-datastore-emulator/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = google-cloud-sdk-datastore-emulator
 	pkgdesc = A google-cloud-sdk component that provides local emulation of a Datastore environment.
 	pkgver = 292.0.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://cloud.google.com/sdk/
 	arch = x86_64
 	license = Apache
-	depends = google-cloud-sdk=292.0.0
+	depends = google-cloud-sdk
 	depends = java-runtime
 	options = !strip
 	source = https://dl.google.com/dl/cloudsdk/release/downloads/for_packagers/linux/google-cloud-sdk-datastore-emulator_292.0.0.orig.tar.gz

--- a/google-cloud-sdk-datastore-emulator/PKGBUILD
+++ b/google-cloud-sdk-datastore-emulator/PKGBUILD
@@ -3,14 +3,14 @@
 
 pkgname=google-cloud-sdk-datastore-emulator
 pkgver=292.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A google-cloud-sdk component that provides local emulation of a Datastore environment."
 url="https://cloud.google.com/sdk/"
 license=("Apache")
 arch=('x86_64')
 options=('!strip')
 depends=(
-  "google-cloud-sdk=${pkgver}"
+  "google-cloud-sdk"
   "java-runtime"
 )
 source=(


### PR DESCRIPTION
If we require a specific version of the `google-cloud-sdk package` in one of the extra components, then this will make it difficult (impossible?) to perform an in-place upgrade of these packages. This is because you can not upgrade the `google-cloud-sdk` package without breaking the existing install of the `google-cloud-sdk-datastore-emulator` package. You also can not build the new `google-cloud-sdk-datastore-emulator` package without the new `google-cloud-sdk package` (since `depends` is both build and run time dependencies) being installed.

I think the best solution to this issue is to just have a dependency on the package name, not a specific version and assume that people will upgrade all of them at the same time (and if they don't, they get to keep the broken pieces).

NOTE1: I am bumping the pkgrel version in the hope that people who have these packages installed will get this update before a pkgver update, allowing them to have a smooth upgrade experience in the future.

NOTE2: I don't have the app-engine related packages installed, but I can not see how they would not also have the same problem, so I am including them in this pull request. I can split this out to just the datastore component if you prefer.