### PR TITLE
feat(terragrunt): adapt to latest version of go packaging guidelines from arch

### DIFF
--- a/terragrunt/.SRCINFO
+++ b/terragrunt/.SRCINFO
@@ -1,15 +1,14 @@
 pkgbase = terragrunt
 	pkgdesc = A thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules
 	pkgver = 0.23.33
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/gruntwork-io/terragrunt
 	arch = x86_64
 	license = MIT
 	makedepends = git
-	makedepends = go-pie
+	makedepends = go
+	depends = glibc
 	depends = terraform
-	provides = terragrunt
-	conflicts = terragrunt
 	source = terragrunt-0.23.33.tar.gz::https://github.com/gruntwork-io/terragrunt/archive/v0.23.33.tar.gz
 	sha256sums = 28e5a3bc2d9ec9ad8a2037680ba28214267ec974f6d8315ad23730c222c6a1fe
 


### PR DESCRIPTION
this pull requests updates the terragrunt PKGBUILD file to the latest version of the [Go package guidelines](https://wiki.archlinux.org/index.php/Go_package_guidelines). I also added all the tests that are easily executable without further hacking.

On a side note, this package is also [reproducible](https://wiki.archlinux.org/index.php/Reproducible_Builds) (not sure if it already was so before).