### PR TITLE
Added missing dependancy

### DIFF
--- a/google-cloud-sdk/PKGBUILD
+++ b/google-cloud-sdk/PKGBUILD
@@ -15,7 +15,7 @@ pkgdesc="A set of command-line tools for the Google Cloud Platform. Includes gcl
 url="https://cloud.google.com/sdk/"
 license=("Apache")
 arch=('x86_64')
-depends=('python')
+depends=('python' 'libxcrypt-compat')
 optdepends=(
   "python2: for dev_appserver.py and endpointscfg support"
   "python-crcmod: [gsutil] verify the integrity of GCS object contents"


### PR DESCRIPTION
Adds [`libxcrypt-compat`](https://archlinux.org/packages/core/x86_64/libxcrypt-compat/) to the dependencies to prevent the following error from happening when using the `gcloud` command:
```
 error while loading shared libraries: libcrypt.so.1: cannot open shared object file: No such file or directory
``` 

This solution is mentioned on the [AUR](https://aur.archlinux.org/packages/google-cloud-sdk) page as well.