### PR TITLE
Update wee-slack to 2.9.0

### DIFF
--- a/wee-slack/.SRCINFO
+++ b/wee-slack/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = wee-slack
 	pkgdesc = A WeeChat plugin for Slack.com
-	pkgver = 2.8.0
+	pkgver = 2.9.0
 	pkgrel = 2
 	url = https://github.com/wee-slack/wee-slack/
 	install = wee-slack.install
@@ -9,8 +9,7 @@ pkgbase = wee-slack
 	depends = weechat
 	depends = python-websocket-client
 	conflicts = wee-slack-git
-	source = wee-slack_2.8.0.tar.gz::https://github.com/wee-slack/wee-slack/archive/v2.8.0.tar.gz
-	sha512sums = 96e778e51c87ca0f51ea60a2b09c3ef3fc8abde563e203b7d1af576ec0bd508e5dc10f93a36172ccbd4abc539a0591a1f71aaeb565105127ee64a832100985ae
+	source = wee-slack_2.9.0.tar.gz::https://github.com/wee-slack/wee-slack/archive/v2.9.0.tar.gz
+	sha512sums = 263cf464a5188488494ce8a7fe56755c5a0379953600953719f60f0a16c0c05e2651f72b2a27ab0c85ad4dbdecfa033371af39dbe6113b75e5ee9d06687ef9b4
 
 pkgname = wee-slack
-

--- a/wee-slack/PKGBUILD
+++ b/wee-slack/PKGBUILD
@@ -5,7 +5,7 @@
 # https://github.com/sudoforge/pkgbuilds
 
 pkgname=wee-slack
-pkgver=2.8.0
+pkgver=2.9.0
 pkgrel=2
 pkgdesc='A WeeChat plugin for Slack.com'
 url='https://github.com/wee-slack/wee-slack/'
@@ -15,7 +15,7 @@ depends=('weechat' 'python-websocket-client')
 conflicts=('wee-slack-git')
 install=$pkgname.install
 source=("${pkgname}_${pkgver}.tar.gz::https://github.com/wee-slack/wee-slack/archive/v${pkgver}.tar.gz")
-sha512sums=('96e778e51c87ca0f51ea60a2b09c3ef3fc8abde563e203b7d1af576ec0bd508e5dc10f93a36172ccbd4abc539a0591a1f71aaeb565105127ee64a832100985ae')
+sha512sums=('263cf464a5188488494ce8a7fe56755c5a0379953600953719f60f0a16c0c05e2651f72b2a27ab0c85ad4dbdecfa033371af39dbe6113b75e5ee9d06687ef9b4')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
The new version of wee-slack fixes some breaking changes made in the Slack API and should be updated soon.