### PR TITLE
[fix] gracefully handle no "updpkgsums" in packages hooks

### DIFF
--- a/.githooks.d/pre-commit/packages.sh
+++ b/.githooks.d/pre-commit/packages.sh
@@ -2,21 +2,21 @@
 
 set -e
 
-_RUNTIME_DEPS=('updpkgsums' 'makepkg' 'git')
+_RUNTIME_DEPS='updpkgsums makepkg git'
 
 check_runtime_deps() {
-  local missing_deps=()
-  for d in "${_RUNTIME_DEPS[@]}"; do
+  missing_deps=""
+  for d in ${_RUNTIME_DEPS}; do
     if ! command -v "$d" > /dev/null; then
-      missing_deps+=("$d")
+      missing_deps="$d $missing_deps"
     fi
   done
-  if [ "${#missing_deps[@]}" -gt 0 ]; then
+  if arg_set "$missing_deps"; then
     >&2 printf "FAIL\n"
-    for d in "${missing_deps[@]}"; do
-      >&2 printf "Command '$d' not found.\n"
+    for d in ${missing_deps}; do
+      >&2 printf "Command '%s' not found.\n" "$d"
     done
-    >&2 printf "Hint: use 'pacman -F ${missing_deps[*]}' to determine which packages to install."
+    >&2 printf "Hint: use 'pacman -F %s' to determine which packages to install." "$missing_deps"
     exit 1
   fi
 }

--- a/.githooks.d/pre-commit/packages.sh
+++ b/.githooks.d/pre-commit/packages.sh
@@ -62,6 +62,11 @@ update_srcinfos() {
   for p in $(get_staged_packages); do
     pushd $p >/dev/null 2>&1
     printf "[ ${p} ] updating package checksums... "
+    if ! command -v updpkgsums > /dev/null; then
+      >&2 printf "FAIL\n"
+      >&2 printf "Command 'updpkgsums' not found. Try installing 'pacman-contrib'."
+      exit 1
+    fi
     if updpkgsums >/dev/null 2>&1; then
       printf "OKAY\n"
       printf "[ ${p} ] updating .SRCINFO... "

--- a/.githooks.d/pre-commit/packages.sh
+++ b/.githooks.d/pre-commit/packages.sh
@@ -2,21 +2,26 @@
 
 set -e
 
-_RUNTIME_DEPS='updpkgsums makepkg git'
+DEPS="updpkgsums makepkg git"
 
 check_runtime_deps() {
-  missing_deps=""
-  for d in ${_RUNTIME_DEPS}; do
-    if ! command -v "$d" > /dev/null; then
-      missing_deps="$d $missing_deps"
+  missing=""
+  for dep in $DEPS; do
+    if ! command -v "$dep" 2>&1 > /dev/null; then
+      if [ -z "$missing" ]; then
+        missing="$dep"
+      else
+        missing="${missing} ${dep}"
+      fi
     fi
   done
-  if arg_set "$missing_deps"; then
-    >&2 printf "FAIL\n"
-    for d in ${missing_deps}; do
-      >&2 printf "Command '%s' not found.\n" "$d"
+  
+  if arg_set "$missing"; then
+    for dep in $missing; do
+      printf "error: command not found: %s\n" "$d" 1>&2
     done
-    >&2 printf "Hint: use 'pacman -F %s' to determine which packages to install." "$missing_deps"
+    
+    printf "fatal: missing required runtime dependencies, aborting.\n" 1>&2
     exit 1
   fi
 }


### PR DESCRIPTION
Without installed:
```
$ git commit -m 'foo'
[ buildifier-bin ] setting pkgrel to '1'
[ buildifier-bin ] updating package checksums... FAIL
Command 'updpkgsums' not found. Try installing 'pacman-contrib'.

```

With installed:
```
$ git commit -m 'foo'
[ buildifier-bin ] setting pkgrel to '1'
[ buildifier-bin ] updating package checksums... OKAY
[ buildifier-bin ] updating .SRCINFO... OKAY
[jamison/buildifier-6 cc2e0eb] foo
 3 files changed, 10 insertions(+), 6 deletions(-)

```