### PR TITLE
feat(buildozer): build with --release=config

### DIFF
--- a/buildozer/.SRCINFO
+++ b/buildozer/.SRCINFO
@@ -1,16 +1,16 @@
 pkgbase = buildozer
 	pkgdesc = A command line tool to rewrite Bazel BUILD files using standard conventions
 	pkgver = 4.2.5
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/bazelbuild/buildtools
 	arch = x86_64
 	license = Apache
 	makedepends = git
 	source = bazelisk-bin-1.11.0::https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
-	source = buildozer-4.2.5.tar.gz::https://github.com/bazelbuild/buildtools/archive/4.2.5.tar.gz
+	source = buildtools-4.2.5::git+https://github.com/bazelbuild/buildtools.git#branch=master
 	source = 0001-copy-buildozer-target-output.patch
 	sha256sums = 231ec5ca8115e94c75a1f4fbada1a062b48822ca04f21f26e4cb1cd8973cd458
-	sha256sums = d368c47bbfc055010f118efb2962987475418737e901f7782d2a966d1dc80296
+	sha256sums = SKIP
 	sha256sums = 68ae2f6ec82afb45baf89c264438c86db35031368b061d8c92036c341f6eb3b1
 
 pkgname = buildozer

--- a/buildozer/PKGBUILD
+++ b/buildozer/PKGBUILD
@@ -6,7 +6,7 @@
 _pkgname=buildtools
 pkgname=buildozer
 pkgver=4.2.5
-pkgrel=1
+pkgrel=2
 pkgdesc='A command line tool to rewrite Bazel BUILD files using standard conventions'
 arch=('x86_64')
 license=('Apache')
@@ -15,16 +15,17 @@ makedepends=('git')
 _bazelisk_pkgver=1.11.0
 source=(
   "bazelisk-bin-${_bazelisk_pkgver}::https://github.com/bazelbuild/bazelisk/releases/download/v${_bazelisk_pkgver}/bazelisk-linux-amd64"
-  "${pkgname}-${pkgver}.tar.gz::${url}/archive/${pkgver}.tar.gz"
+  "${_pkgname}-${pkgver}::git+${url}.git#branch=master"
   "0001-copy-buildozer-target-output.patch"
 )
 sha256sums=('231ec5ca8115e94c75a1f4fbada1a062b48822ca04f21f26e4cb1cd8973cd458'
-            'd368c47bbfc055010f118efb2962987475418737e901f7782d2a966d1dc80296'
+            'SKIP'
             '68ae2f6ec82afb45baf89c264438c86db35031368b061d8c92036c341f6eb3b1')
 
 prepare() {
   cd "${srcdir}/${_pkgname}-${pkgver}"
-
+  git fetch origin "${pkgver}" > /dev/null 2>&1
+  git checkout "${pkgver}" > /dev/null 2>&1
   for f in "${source[@]}"; do
     [[ "$f" =~ \.patch$ ]] && \
     ( \
@@ -41,7 +42,7 @@ prepare() {
 
 build() {
   cd "${srcdir}/${_pkgname}-${pkgver}"
-  "${srcdir}/${source[0]%%::*}" build "//${pkgname}:${pkgname}-linux"
+  "${srcdir}/${source[0]%%::*}" build --config=release "//${pkgname}:${pkgname}-linux"
   "${srcdir}/${source[0]%%::*}" shutdown
 }
 


### PR DESCRIPTION
Bazel's buildtools get their versioned stamped when `--config=release` is used as defined in their [.bazelrc](https://github.com/bazelbuild/buildtools/blob/a6ca93fd072d573a22963c6213abeaca99e6b740/.bazelrc#LL1). (This also builds  with `-c opt` which is also generally nice.)

Since their `status.py` calls `git describe`, I needed to clone the repo rather than just download the tarball.

Closes https://github.com/sudoforge/pkgbuilds/issues/87